### PR TITLE
use createObjectStore() for Filesystem example

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Pass _path_ option to specify directory where the files will be stored. The path
 
 var FsBackend = require('warehousejs/backend/fs'),
     backend = new FsBackend({path: '/path/to/storage'}),
-    store = backend.objectStore('item');
+    store = backend.createObjectStore('item');
 ```
 
 ### ElasticSearch


### PR DESCRIPTION
When using the example, I had difficulty with the Filesystem backend not persisting data. I then realized that createObjectStore('item') had to be called at least once so that the "item" directory is created in /path/to/storage. The persisting started working after that.
