### PR TITLE
Make compatible with Elasticsearch >0.90

### DIFF
--- a/backend/elasticsearch.js
+++ b/backend/elasticsearch.js
@@ -148,7 +148,7 @@ var ElasticSearchStore = BaseBackend.BaseStore.extend(
         var key = this._getObjectKey({}, directives);
 
         function handle(result) {
-                if (result && result.ok) {
+                if (result && result.found) {
                     return result.found ? 1 : 0;
                 } else if (result && result.responseText) {
                     result = JSON.parse(result.responseText);

--- a/backend/elasticsearch.js
+++ b/backend/elasticsearch.js
@@ -166,8 +166,8 @@ var ElasticSearchStore = BaseBackend.BaseStore.extend(
     query: function(query) {
         var q = rql2es(_.rql(query)),
             mapFn = q.fields ?
-                          function(x) { return x.fields; }
-                        : function(x) { return x._source; };
+                          function(x) { return _.extend({}, {'id': x._id}, x.fields); }
+                        : function(x) { return _.extend({}, {'id': x._id}, x._source); };
         return ajax('POST', this._url + '/_search', q)
             .then(function(result) {
                 return result.hits.hits.map(mapFn);


### PR DESCRIPTION
I'm not sure if there are people who are using ES <= 0.90. The returned JSON when creating or updating documents has changed slightly.

OLD:

``` javascript
{
    "ok" : true,
    "_index" : "twitter",
    "_type" : "tweet",
    "_id" : "1",
    "_version" : 1
}
```

NEW:

``` javascript
{
    "_shards" : {
        "total" : 10,
        "failed" : 0,
        "successful" : 10
    },
    "_index" : "twitter",
    "_type" : "tweet",
    "_id" : "1",
    "_version" : 1,
    "created" : true
}
```

And when updating a document the key `created` is `false`, so I make a check for successful `_shards`. This is a quick and dirty proof-of-concept and definately needs some review since I'm a total ElasticSearch noob. :grinning: 
